### PR TITLE
Added support to write byte arrays.

### DIFF
--- a/src/KristofferStrube.Blazor.FileSystemAccess/FileSystemWritableFileStream.cs
+++ b/src/KristofferStrube.Blazor.FileSystemAccess/FileSystemWritableFileStream.cs
@@ -20,6 +20,10 @@ public class FileSystemWritableFileStream
     {
         await jSReference.InvokeVoidAsync("write", data);
     }
+    public async Task WriteAsync(byte[] data)
+    {
+        await jSReference.InvokeVoidAsync("write", data);
+    }
     public async Task WriteAsync(Blob data)
     {
         await jSReference.InvokeVoidAsync("write", data.JSReference);
@@ -29,6 +33,10 @@ public class FileSystemWritableFileStream
         await helper.InvokeVoidAsync("WriteBlobWriteParams", jSReference, data, data.Data?.JSReference);
     }
     public async Task WriteAsync(StringWriteParams data)
+    {
+        await jSReference.InvokeVoidAsync("write", data);
+    }
+    public async Task WriteAsync(ByteArrayWriteParams data)
     {
         await jSReference.InvokeVoidAsync("write", data);
     }

--- a/src/KristofferStrube.Blazor.FileSystemAccess/Options/WriteParams.cs
+++ b/src/KristofferStrube.Blazor.FileSystemAccess/Options/WriteParams.cs
@@ -45,3 +45,25 @@ public class StringWriteParams
     [JsonPropertyName("data")]
     public string? Data { get; set; }
 }
+
+public class ByteArrayWriteParams
+{
+    public ByteArrayWriteParams(WriteCommandType type)
+    {
+
+    }
+
+    [JsonPropertyName("type")]
+    public WriteCommandType Type { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("size")]
+    public ulong Size { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("position")]
+    public ulong Position { get; set; }
+
+    [JsonPropertyName("data")]
+    public byte[]? Data { get; set; }
+}


### PR DESCRIPTION
Added support to write byte arrays.

Converting byte array to string using stream reader - readToEnd will convert to byte array to string but it will also add UTF8(?) encoding. This causes the file saved not to contain the same bytes as "just" writing the raw byte array.