### PR TITLE
Fixed broken `Multiple` property

### DIFF
--- a/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/MultipleFiles.razor
+++ b/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/MultipleFiles.razor
@@ -1,0 +1,35 @@
+@page "/MultipleFiles"
+@inject FileSystemAccessService FileSystemAccessService
+
+<PageTitle>Open Multiple Files</PageTitle>
+
+<button @onclick="OpenMultipleFilePicker" class="btn btn-primary">Open File Picker for Multiple Files</button>
+
+@if(filesRead is not null)
+{
+    <p>You selected @filesRead.Count files.</p>
+    <ul>
+        @foreach(var file in filesRead)
+        {
+            <li>@file</li>
+        }
+    </ul>
+}
+
+@code {
+    private List<string> filesRead;
+
+    private async Task OpenMultipleFilePicker()
+    {
+        try
+        {
+            var options = new OpenFilePickerOptionsStartInWellKnownDirectory() { Multiple = true, StartIn = WellKnownDirectory.Downloads };
+            var fileHandles = await FileSystemAccessService.ShowOpenFilePickerAsync(options);
+            filesRead = fileHandles.Select(x => x.Name).ToList();
+        }
+        catch (JSException ex)
+        {
+            Console.WriteLine(ex);
+        }
+    }
+}

--- a/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Shared/NavMenu.razor
+++ b/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Shared/NavMenu.razor
@@ -20,6 +20,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="MultipleFiles">
+                <span class="oi oi-layers" aria-hidden="true"></span> Open Multiple Files
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="OriginPrivate">
                 <span class="oi oi-browser" aria-hidden="true"></span> Origin Private
             </NavLink>

--- a/src/KristofferStrube.Blazor.FileSystemAccess/Options/OpenFilePickerOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystemAccess/Options/OpenFilePickerOptions.cs
@@ -12,7 +12,7 @@ public class OpenFilePickerOptionsStartInWellKnownDirectory : FilePickerOptionsS
     internal new ExpandoObject Serializable()
     {
         dynamic res = base.Serializable();
-        if (!Multiple)
+        if (Multiple)
         {
             res.multiple = Multiple;
         }
@@ -31,7 +31,7 @@ public class OpenFilePickerOptionsStartInInFileSystemHandle : FilePickerOptionsS
     internal new ExpandoObject Serializable()
     {
         dynamic res = base.Serializable();
-        if (!Multiple)
+        if (Multiple)
         {
             res.multiple = Multiple;
         }


### PR DESCRIPTION
Hi. Thanks for making this great package.

I noticed that the `Multiple` property on `OpenFilePickerOptionsStartInWellKnownDirectory` and `OpenFilePickerOptionsStartInWellKnownDirectory` did not work. No matter what the property was set to, it would always just open in "single-file" or "single-directory" mode.
This seemed to be because of an inverted if-check. 

I built it locally with the proposed changes, which fixed the issue.