### PR TITLE
FileSystemWritableFileStream as a Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `FileSystemWritableStream` now extends the `Stream`.
+### Added
 - Added support for Origin Private File System via `GetOriginPrivateDirectory` method that wraps the JS call `navigator.storage.getDirectory`.
 ### Changed
 - Changed `RemoveEntryAsync` to use `FileSystemRemoveOptions` instead of `FileSystemGetFileOptions` and created the `FileSystemRemoveOptions` class.

--- a/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/InputFileExample.razor
+++ b/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/InputFileExample.razor
@@ -6,29 +6,37 @@
 We can read the bytes from a <code>IBrowserFile</code> from the native <code>InputFile</code> component and write these to the <code>FileSystemWritableFileStream</code>.
 <br />
 <br />
-@if (SaveFileHandle is null)
+@if (readFile is not null)
 {
-    <button class="btn btn-primary" @onclick=Save>Choose File to Save to</button>
+    <h3>Currently streaming...</h3>
+}
+else if (SaveFileHandle is not null)
+{
+    <text>Choose file to Stream From</text>
+    <br />
+    <InputFile OnChange="OnChange" />
 }
 else
 {
-    <InputFile OnChange="OnChange" class="btn btn-primary" />
+    <button class="btn btn-primary" @onclick=Save>Choose File to Stream To</button>
 }
 
 @code {
     FileSystemFileHandle? SaveFileHandle;
+    IBrowserFile? readFile;
 
     public async Task OnChange(InputFileChangeEventArgs args)
     {
         if (SaveFileHandle is not null)
         {
-            var file = args.File;
-            using var stream = file.OpenReadStream();
-            var writable = await SaveFileHandle.CreateWritableAsync(new() { KeepExistingData = false });
+            readFile = args.File;
+            
+            using var stream = readFile.OpenReadStream(maxAllowedSize: 10000000000);
+            using var writable = await SaveFileHandle.CreateWritableAsync(new() { KeepExistingData = false });
             await stream.CopyToAsync(writable);
-            var saveFile = await SaveFileHandle.GetFileAsync();
-            var text = await saveFile.TextAsync();
-            Console.WriteLine(text);
+            SaveFileHandle = null;
+            readFile = null;
+            Console.WriteLine("Done streaming!");
         }
     }
 

--- a/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/InputFileExample.razor
+++ b/samples/KristofferStrube.Blazor.FileSystemAccess.WasmExample/Pages/InputFileExample.razor
@@ -6,33 +6,35 @@
 We can read the bytes from a <code>IBrowserFile</code> from the native <code>InputFile</code> component and write these to the <code>FileSystemWritableFileStream</code>.
 <br />
 <br />
-<InputFile OnChange="OnChange" class="btn btn-primary" />
-@if (buffer is not null)
+@if (SaveFileHandle is null)
 {
-    <br />
-    <br />
-    <button class="btn btn-success" @onclick="Save">Save</button>
+    <button class="btn btn-primary" @onclick=Save>Choose File to Save to</button>
+}
+else
+{
+    <InputFile OnChange="OnChange" class="btn btn-primary" />
 }
 
 @code {
-    public byte[]? buffer;
+    FileSystemFileHandle? SaveFileHandle;
 
     public async Task OnChange(InputFileChangeEventArgs args)
     {
-        var file = args.File;
-        using var stream = file.OpenReadStream();
-        buffer = new byte[stream.Length];
-        await stream.ReadAsync(buffer);
+        if (SaveFileHandle is not null)
+        {
+            var file = args.File;
+            using var stream = file.OpenReadStream();
+            var writable = await SaveFileHandle.CreateWritableAsync(new() { KeepExistingData = false });
+            await stream.CopyToAsync(writable);
+            var saveFile = await SaveFileHandle.GetFileAsync();
+            var text = await saveFile.TextAsync();
+            Console.WriteLine(text);
+        }
     }
 
     public async Task Save()
     {
-        if(buffer is not null)
-        {
-            var fileHandle = await FileSystemAccessService.ShowSaveFilePickerAsync();
-            var writable = await fileHandle.CreateWritableAsync();
-            await writable.WriteAsync(buffer);
-            await writable.CloseAsync();
-        }
+        SaveFileHandle = await FileSystemAccessService.ShowSaveFilePickerAsync();
+        StateHasChanged();
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystemAccess/wwwroot/KristofferStrube.Blazor.FileSystemAccess.js
+++ b/src/KristofferStrube.Blazor.FileSystemAccess/wwwroot/KristofferStrube.Blazor.FileSystemAccess.js
@@ -14,3 +14,26 @@ export function WriteBlobWriteParams(fileSystemWritableFileStream, writeParams, 
     writeParams.data = blob;
     fileSystemWritableFileStream.write(writeParams);
 }
+
+// Methods for FileSystemWritableFileStream
+
+export function close(fileSystemWritableFileStream) {
+    fileSystemWritableFileStream.close();
+}
+
+export function seek(fileSystemWritableFileStream, position) {
+    fileSystemWritableFileStream.seek(position);
+}
+
+export function truncate(fileSystemWritableFileStream, size) {
+    fileSystemWritableFileStream.seek(size);
+}
+
+export function write(fileSystemWritableFileStream, buffer, offset) {
+    var writeParams = {
+        type: "write",
+        position: offset,
+        data: buffer
+    };
+    fileSystemWritableFileStream.write(writeParams);
+}

--- a/src/KristofferStrube.Blazor.FileSystemAccess/wwwroot/KristofferStrube.Blazor.FileSystemAccess.js
+++ b/src/KristofferStrube.Blazor.FileSystemAccess/wwwroot/KristofferStrube.Blazor.FileSystemAccess.js
@@ -14,26 +14,3 @@ export function WriteBlobWriteParams(fileSystemWritableFileStream, writeParams, 
     writeParams.data = blob;
     fileSystemWritableFileStream.write(writeParams);
 }
-
-// Methods for FileSystemWritableFileStream
-
-export function close(fileSystemWritableFileStream) {
-    fileSystemWritableFileStream.close();
-}
-
-export function seek(fileSystemWritableFileStream, position) {
-    fileSystemWritableFileStream.seek(position);
-}
-
-export function truncate(fileSystemWritableFileStream, size) {
-    fileSystemWritableFileStream.seek(size);
-}
-
-export function write(fileSystemWritableFileStream, buffer, offset) {
-    var writeParams = {
-        type: "write",
-        position: offset,
-        data: buffer
-    };
-    fileSystemWritableFileStream.write(writeParams);
-}


### PR DESCRIPTION
This PR solves #8 by making it easier to write a `Stream` to the `FileSystemWritableFileStream`.